### PR TITLE
Implement theme personalization with backend

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id("org.springframework.boot") version "3.3.0"
+    id("io.spring.dependency-management") version "1.1.4"
+    kotlin("jvm") version "2.0.0"
+    kotlin("plugin.spring") version "2.0.0"
+}
+
+group = "com.example"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_21
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    runtimeOnly("com.h2database:h2")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/server/settings.gradle.kts
+++ b/server/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "theme-server"

--- a/server/src/main/kotlin/com/example/theme/ThemeServerApplication.kt
+++ b/server/src/main/kotlin/com/example/theme/ThemeServerApplication.kt
@@ -1,0 +1,11 @@
+package com.example.theme
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class ThemeServerApplication
+
+fun main(args: Array<String>) {
+    runApplication<ThemeServerApplication>(*args)
+}

--- a/server/src/main/kotlin/com/example/theme/config/DataLoader.kt
+++ b/server/src/main/kotlin/com/example/theme/config/DataLoader.kt
@@ -1,0 +1,41 @@
+package com.example.theme.config
+
+import com.example.theme.entity.PredefinedTheme
+import com.example.theme.repo.PredefinedThemeRepository
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+
+@Component
+class DataLoader(private val repo: PredefinedThemeRepository) {
+    @PostConstruct
+    fun init() {
+        if (repo.count() == 0L) {
+            val mapper = jacksonObjectMapper()
+            val themes = listOf(
+                PredefinedTheme(name = "Light", description = "Default light", colors = mapper.writeValueAsString(mapOf(
+                    "primary" to "#7E69AB",
+                    "secondary" to "#1EAEDB",
+                    "background" to "#ffffff",
+                    "foreground" to "#0a0a0a",
+                    "accent" to "#f4f4f5"
+                )), isDark = false),
+                PredefinedTheme(name = "Dark", description = "Dark mode", colors = mapper.writeValueAsString(mapOf(
+                    "primary" to "#9b87f5",
+                    "secondary" to "#33C3F0",
+                    "background" to "#0a0a0a",
+                    "foreground" to "#fafafa",
+                    "accent" to "#27272a"
+                )), isDark = true),
+                PredefinedTheme(name = "Ocean", description = "Ocean blue", colors = mapper.writeValueAsString(mapOf(
+                    "primary" to "#0891b2",
+                    "secondary" to "#06b6d4",
+                    "background" to "#f0f9ff",
+                    "foreground" to "#0c4a6e",
+                    "accent" to "#e0f2fe"
+                )), isDark = false)
+            )
+            repo.saveAll(themes)
+        }
+    }
+}

--- a/server/src/main/kotlin/com/example/theme/controller/ThemeController.kt
+++ b/server/src/main/kotlin/com/example/theme/controller/ThemeController.kt
@@ -1,0 +1,40 @@
+package com.example.theme.controller
+
+import com.example.theme.dto.ThemeDto
+import com.example.theme.entity.UserThemeSetting
+import com.example.theme.service.ThemeService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api")
+class ThemeController(private val service: ThemeService) {
+
+    @GetMapping("/themes")
+    fun predefined(): List<ThemeDto> = service.getPredefined()
+
+    @GetMapping("/users/{userId}/presets")
+    fun presets(@PathVariable userId: Long): List<ThemeDto> = service.getPresets(userId)
+
+    @PostMapping("/users/{userId}/presets")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun createPreset(@PathVariable userId: Long, @RequestBody dto: ThemeDto): ThemeDto =
+        service.createPreset(userId, dto)
+
+    @DeleteMapping("/users/{userId}/presets/{presetId}")
+    fun deletePreset(@PathVariable userId: Long, @PathVariable presetId: Long) =
+        service.deletePreset(userId, presetId)
+
+    @GetMapping("/users/{userId}/theme")
+    fun active(@PathVariable userId: Long): UserThemeSetting? = service.getActive(userId)
+
+    @PutMapping("/users/{userId}/theme")
+    fun setActive(
+        @PathVariable userId: Long,
+        @RequestParam(required = false) themeId: Long?,
+        @RequestParam(required = false) presetId: Long?
+    ) = service.setActive(userId, themeId, presetId)
+
+    @PostMapping("/users/{userId}/reset-personalization")
+    fun reset(@PathVariable userId: Long) = service.reset(userId)
+}

--- a/server/src/main/kotlin/com/example/theme/dto/ThemeDto.kt
+++ b/server/src/main/kotlin/com/example/theme/dto/ThemeDto.kt
@@ -1,0 +1,9 @@
+package com.example.theme.dto
+
+data class ThemeDto(
+    val id: Long? = null,
+    val name: String,
+    val description: String? = null,
+    val colors: Map<String, String>,
+    val isDark: Boolean = false
+)

--- a/server/src/main/kotlin/com/example/theme/entity/PredefinedTheme.kt
+++ b/server/src/main/kotlin/com/example/theme/entity/PredefinedTheme.kt
@@ -1,0 +1,15 @@
+package com.example.theme.entity
+
+import jakarta.persistence.*
+
+@Entity
+class PredefinedTheme(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    var name: String = "",
+    var description: String? = null,
+    @Column(columnDefinition = "json")
+    var colors: String = "{}",
+    var isActive: Boolean = true,
+    var isDark: Boolean = false
+)

--- a/server/src/main/kotlin/com/example/theme/entity/UserThemePreset.kt
+++ b/server/src/main/kotlin/com/example/theme/entity/UserThemePreset.kt
@@ -1,0 +1,17 @@
+package com.example.theme.entity
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+class UserThemePreset(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    var userId: Long = 0,
+    var name: String = "",
+    @Column(columnDefinition = "json")
+    var colors: String = "{}",
+    var isDark: Boolean = false,
+    var createdAt: LocalDateTime? = null,
+    var updatedAt: LocalDateTime? = null
+)

--- a/server/src/main/kotlin/com/example/theme/entity/UserThemeSetting.kt
+++ b/server/src/main/kotlin/com/example/theme/entity/UserThemeSetting.kt
@@ -1,0 +1,14 @@
+package com.example.theme.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import java.time.LocalDateTime
+
+@Entity
+class UserThemeSetting(
+    @Id
+    var userId: Long = 0,
+    var activeThemeId: Long? = null,
+    var activePresetId: Long? = null,
+    var updatedAt: LocalDateTime? = null
+)

--- a/server/src/main/kotlin/com/example/theme/repo/PredefinedThemeRepository.kt
+++ b/server/src/main/kotlin/com/example/theme/repo/PredefinedThemeRepository.kt
@@ -1,0 +1,6 @@
+package com.example.theme.repo
+
+import com.example.theme.entity.PredefinedTheme
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PredefinedThemeRepository : JpaRepository<PredefinedTheme, Long>

--- a/server/src/main/kotlin/com/example/theme/repo/UserThemePresetRepository.kt
+++ b/server/src/main/kotlin/com/example/theme/repo/UserThemePresetRepository.kt
@@ -1,0 +1,8 @@
+package com.example.theme.repo
+
+import com.example.theme.entity.UserThemePreset
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserThemePresetRepository : JpaRepository<UserThemePreset, Long> {
+    fun findByUserId(userId: Long): List<UserThemePreset>
+}

--- a/server/src/main/kotlin/com/example/theme/repo/UserThemeSettingRepository.kt
+++ b/server/src/main/kotlin/com/example/theme/repo/UserThemeSettingRepository.kt
@@ -1,0 +1,6 @@
+package com.example.theme.repo
+
+import com.example.theme.entity.UserThemeSetting
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserThemeSettingRepository : JpaRepository<UserThemeSetting, Long>

--- a/server/src/main/kotlin/com/example/theme/service/ThemeService.kt
+++ b/server/src/main/kotlin/com/example/theme/service/ThemeService.kt
@@ -1,0 +1,62 @@
+package com.example.theme.service
+
+import com.example.theme.dto.ThemeDto
+import com.example.theme.entity.PredefinedTheme
+import com.example.theme.entity.UserThemePreset
+import com.example.theme.entity.UserThemeSetting
+import com.example.theme.repo.PredefinedThemeRepository
+import com.example.theme.repo.UserThemePresetRepository
+import com.example.theme.repo.UserThemeSettingRepository
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+@Service
+class ThemeService(
+    private val predefinedRepo: PredefinedThemeRepository,
+    private val presetRepo: UserThemePresetRepository,
+    private val settingRepo: UserThemeSettingRepository
+) {
+    private val mapper = jacksonObjectMapper()
+
+    fun getPredefined(): List<ThemeDto> =
+        predefinedRepo.findAll().filter { it.isActive }.map { it.toDto() }
+
+    fun getPresets(userId: Long): List<ThemeDto> =
+        presetRepo.findByUserId(userId).map { it.toDto() }
+
+    fun createPreset(userId: Long, dto: ThemeDto): ThemeDto {
+        val preset = UserThemePreset(
+            userId = userId,
+            name = dto.name,
+            colors = mapper.writeValueAsString(dto.colors),
+            isDark = dto.isDark,
+            createdAt = LocalDateTime.now(),
+            updatedAt = LocalDateTime.now()
+        )
+        return presetRepo.save(preset).toDto()
+    }
+
+    fun deletePreset(userId: Long, presetId: Long) {
+        presetRepo.findById(presetId).ifPresent {
+            if (it.userId == userId) presetRepo.delete(it)
+        }
+    }
+
+    fun setActive(userId: Long, themeId: Long?, presetId: Long?) {
+        val setting = settingRepo.findById(userId).orElse(UserThemeSetting(userId))
+        setting.activeThemeId = themeId
+        setting.activePresetId = presetId
+        setting.updatedAt = LocalDateTime.now()
+        settingRepo.save(setting)
+    }
+
+    fun getActive(userId: Long): UserThemeSetting? = settingRepo.findById(userId).orElse(null)
+
+    fun reset(userId: Long) {
+        settingRepo.deleteById(userId)
+    }
+
+    private fun PredefinedTheme.toDto() = ThemeDto(id, name, description, mapper.readValue(colors, Map::class.java) as Map<String, String>, isDark)
+    private fun UserThemePreset.toDto() = ThemeDto(id, name, null, mapper.readValue(colors, Map::class.java) as Map<String, String>, isDark)
+}

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.datasource.url=jdbc:h2:mem:themes;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true

--- a/server/src/test/kotlin/com/example/theme/ThemeServerApplicationTests.kt
+++ b/server/src/test/kotlin/com/example/theme/ThemeServerApplicationTests.kt
@@ -1,0 +1,11 @@
+package com.example.theme
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class ThemeServerApplicationTests {
+    @Test
+    fun contextLoads() {
+    }
+}

--- a/src/components/ThemeSelector.vue
+++ b/src/components/ThemeSelector.vue
@@ -220,105 +220,33 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useAuthStore } from '@/stores/auth'
+import {
+  getPredefinedThemes,
+  getUserPresets,
+  createUserPreset,
+  deleteUserPreset,
+  setActiveTheme,
+  getActiveTheme,
+  resetPersonalization,
+  type Theme as ApiTheme
+} from '@/service/ThemeService'
+
+const authStore = useAuthStore()
 
 // ----------------- Theme Types & Data ---------------------
-interface Theme {
-  id: string
-  name: string
-  colors: Record<string, string>
-  isDark: boolean
-  description?: string
-}
+type Theme = ApiTheme
 
-const predefinedThemes: Theme[] = [
-  {
-    id: 'light',
-    name: 'Light',
-    description: 'Clean and bright design perfect for daytime use',
-    colors: {
-      primary: '#7E69AB',
-      secondary: '#1EAEDB',
-      background: '#ffffff',
-      foreground: '#0a0a0a',
-      accent: '#f4f4f5',
-    },
-    isDark: false,
-  },
-  {
-    id: 'dark',
-    name: 'Dark',
-    description: 'Easy on the eyes for low-light environments',
-    colors: {
-      primary: '#9b87f5',
-      secondary: '#33C3F0',
-      background: '#0a0a0a',
-      foreground: '#fafafa',
-      accent: '#27272a',
-    },
-    isDark: true,
-  },
-  {
-    id: 'ocean',
-    name: 'Ocean',
-    description: 'Calming blue tones inspired by the sea',
-    colors: {
-      primary: '#0891b2',
-      secondary: '#06b6d4',
-      background: '#f0f9ff',
-      foreground: '#0c4a6e',
-      accent: '#e0f2fe',
-    },
-    isDark: false,
-  },
-  {
-    id: 'sunset',
-    name: 'Sunset',
-    description: 'Warm oranges and purples like a beautiful sunset',
-    colors: {
-      primary: '#ea580c',
-      secondary: '#f97316',
-      background: '#fff7ed',
-      foreground: '#9a3412',
-      accent: '#fed7aa',
-    },
-    isDark: false,
-  },
-  {
-    id: 'forest',
-    name: 'Forest',
-    description: 'Natural greens bringing the outdoors inside',
-    colors: {
-      primary: '#059669',
-      secondary: '#10b981',
-      background: '#f0fdf4',
-      foreground: '#064e3b',
-      accent: '#bbf7d0',
-    },
-    isDark: false,
-  },
-  {
-    id: 'midnight',
-    name: 'Midnight',
-    description: 'Deep blues and purples for the night owls',
-    colors: {
-      primary: '#6366f1',
-      secondary: '#8b5cf6',
-      background: '#0f172a',
-      foreground: '#f1f5f9',
-      accent: '#1e293b',
-    },
-    isDark: true,
-  },
-]
+const predefinedThemes = ref<Theme[]>([])
 
 // ----------------- States ---------------------
-const currentTheme = ref<Theme>(predefinedThemes[0])
+const currentTheme = ref<Theme | null>(null)
 const previewTheme = ref<Theme | null>(null)
 const isPreviewMode = ref(false)
 const customThemeName = ref('')
 const savedThemes = ref<Theme[]>([])
 const customTheme = ref<Theme>({
-  id: 'custom',
+  id: 0,
   name: 'Custom Theme',
   colors: {
     primary: '#7e69ab',
@@ -343,12 +271,20 @@ function applyThemeToDOM(theme: Theme) {
     root.classList.remove('dark')
   }
 }
-function applyTheme(theme: Theme) {
+async function applyTheme(theme: Theme) {
   applyThemeToDOM(theme)
   currentTheme.value = theme
   previewTheme.value = null
   isPreviewMode.value = false
-  localStorage.setItem('enhancedCurrentTheme', JSON.stringify(theme))
+  const userId = authStore.currentUserId
+  if (userId) {
+    const preset = savedThemes.value.find(t => t.id === theme.id)
+    if (preset) {
+      await setActiveTheme(userId, undefined, preset.id)
+    } else {
+      await setActiveTheme(userId, theme.id, undefined)
+    }
+  }
 }
 function handlePreview(theme: Theme) {
   previewTheme.value = theme
@@ -374,46 +310,65 @@ function updateCustomColorMode() {
   applyThemeToDOM(customTheme.value)
 }
 function applyCustomTheme() {
-  const theme = { ...customTheme.value, id: `custom-${Date.now()}` }
+  const theme = { ...customTheme.value }
   applyTheme(theme)
 }
-function saveCustomTheme() {
+async function saveCustomTheme() {
   if (!customThemeName.value.trim()) return
   const newTheme: Theme = {
-    id: `custom-${Date.now()}`,
+    id: 0,
     name: customThemeName.value,
     colors: { ...customTheme.value.colors },
     isDark: customTheme.value.isDark,
-    description: 'Custom theme created by user',
   }
-  savedThemes.value.push(newTheme)
-  localStorage.setItem('enhancedSavedThemes', JSON.stringify(savedThemes.value))
+  const userId = authStore.currentUserId
+  if (userId) {
+    const created = await createUserPreset(userId, newTheme)
+    savedThemes.value.push(created)
+  }
   customThemeName.value = ''
 }
-function deleteCustomTheme(themeId: string) {
-  savedThemes.value = savedThemes.value.filter((t) => t.id !== themeId)
-  localStorage.setItem('enhancedSavedThemes', JSON.stringify(savedThemes.value))
-}
-function resetToDefaults() {
-  savedThemes.value = []
-  customTheme.value = {
-    ...customTheme.value,
-    colors: { ...predefinedThemes[0].colors },
-    isDark: predefinedThemes[0].isDark,
+async function deleteCustomTheme(themeId: number) {
+  const userId = authStore.currentUserId
+  if (userId) {
+    await deleteUserPreset(userId, themeId)
+    savedThemes.value = savedThemes.value.filter((t) => t.id !== themeId)
   }
-  applyTheme(predefinedThemes[0])
-  localStorage.removeItem('enhancedSavedThemes')
-  localStorage.removeItem('enhancedCurrentTheme')
+}
+async function resetToDefaults() {
+  const userId = authStore.currentUserId
+  if (userId) {
+    await resetPersonalization(userId)
+  }
+  if (predefinedThemes.value.length > 0) {
+    customTheme.value = {
+      ...customTheme.value,
+      colors: { ...predefinedThemes.value[0].colors },
+      isDark: predefinedThemes.value[0].isDark,
+    }
+    applyTheme(predefinedThemes.value[0])
+  }
 }
 
-onMounted(() => {
-  const saved = localStorage.getItem('enhancedSavedThemes')
-  if (saved) savedThemes.value = JSON.parse(saved)
-  const currentSaved = localStorage.getItem('enhancedCurrentTheme')
-  if (currentSaved) {
-    const parsedTheme = JSON.parse(currentSaved)
-    currentTheme.value = parsedTheme
-    applyThemeToDOM(parsedTheme)
+onMounted(async () => {
+  predefinedThemes.value = await getPredefinedThemes()
+  const userId = authStore.currentUserId
+  if (userId) {
+    savedThemes.value = await getUserPresets(userId)
+    const active = await getActiveTheme(userId)
+    let theme: Theme | undefined
+    if (active?.activePresetId) {
+      theme = savedThemes.value.find(t => t.id === active.activePresetId)
+    } else if (active?.activeThemeId) {
+      theme = predefinedThemes.value.find(t => t.id === active.activeThemeId)
+    }
+    if (theme) {
+      await applyTheme(theme)
+    } else if (predefinedThemes.value.length > 0) {
+      await applyTheme(predefinedThemes.value[0])
+    }
+  } else if (predefinedThemes.value.length > 0) {
+    await applyTheme(predefinedThemes.value[0])
   }
 })
 </script>

--- a/src/service/ThemeService.ts
+++ b/src/service/ThemeService.ts
@@ -1,0 +1,41 @@
+import api from './api'
+
+export interface Theme {
+  id?: number
+  name: string
+  description?: string
+  colors: Record<string, string>
+  isDark: boolean
+}
+
+export async function getPredefinedThemes() {
+  const res = await api.get<Theme[]>('/themes')
+  return res.data
+}
+
+export async function getUserPresets(userId: number) {
+  const res = await api.get<Theme[]>(`/users/${userId}/presets`)
+  return res.data
+}
+
+export async function createUserPreset(userId: number, payload: Theme) {
+  const res = await api.post<Theme>(`/users/${userId}/presets`, payload)
+  return res.data
+}
+
+export async function deleteUserPreset(userId: number, presetId: number) {
+  await api.delete(`/users/${userId}/presets/${presetId}`)
+}
+
+export async function setActiveTheme(userId: number, themeId?: number, presetId?: number) {
+  await api.put(`/users/${userId}/theme`, null, { params: { themeId, presetId } })
+}
+
+export async function getActiveTheme(userId: number) {
+  const res = await api.get(`/users/${userId}/theme`)
+  return res.data
+}
+
+export async function resetPersonalization(userId: number) {
+  await api.post(`/users/${userId}/reset-personalization`)
+}


### PR DESCRIPTION
## Summary
- add Spring Boot backend under `server` with theme entities, repositories, service, controller
- preload sample themes via data loader
- provide ThemeService API for frontend
- integrate ThemeSelector component with backend APIs

## Testing
- `npm run lint` *(fails: run-s not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858c3992d60832293d5e987ff818a73