### PR TITLE
Add validation for manual content forms

### DIFF
--- a/src/views/ManualGenerate_view/FlashcardView.vue
+++ b/src/views/ManualGenerate_view/FlashcardView.vue
@@ -325,9 +325,13 @@ const handleSave = async () => {
     return
   }
 
-  const validCards = cards.value.filter((card) => card.front.trim() && card.back.trim())
-  if (validCards.length === 0) {
-    errorMessage.value = 'Please add at least one complete flashcard'
+  if (cards.value.length === 0) {
+    errorMessage.value = 'Please add at least one flashcard'
+    return
+  }
+
+  if (cards.value.some((card) => !card.front.trim() || !card.back.trim())) {
+    errorMessage.value = 'All flashcards must have both front and back filled'
     return
   }
 
@@ -344,7 +348,7 @@ const handleSave = async () => {
         .map((tag) => tag.trim())
         .filter((tag) => tag),
       difficulty: difficulty.value,
-      cards: validCards,
+      cards: cards.value,
     }
 
     await createFlashcardDeck(flashcardDeck)

--- a/src/views/ManualGenerate_view/NoteView.vue
+++ b/src/views/ManualGenerate_view/NoteView.vue
@@ -324,6 +324,21 @@ const getInputType = (type: string) => {
 }
 
 const saveNote = async () => {
+  if (!noteData.title.trim()) {
+    errorMessage.value = 'Please enter a note title'
+    return
+  }
+
+  const content = noteData.blocks
+    .map((block) => block.content)
+    .filter((text) => text.trim())
+    .join('\n')
+
+  if (!content.trim()) {
+    errorMessage.value = 'Please enter note content'
+    return
+  }
+
   isLoading.value = true
   errorMessage.value = ''
   successMessage.value = ''
@@ -333,12 +348,6 @@ const saveNote = async () => {
       .split(',')
       .map((tag) => tag.trim())
       .filter((tag) => tag)
-
-    // Combine blocks into content
-    const content = noteData.blocks
-      .map((block) => block.content)
-      .filter((text) => text.trim())
-      .join('\n')
 
     const notePayload = {
       title: noteData.title,

--- a/src/views/ManualGenerate_view/QuizView.vue
+++ b/src/views/ManualGenerate_view/QuizView.vue
@@ -334,12 +334,42 @@ function onBack() {
 }
 
 async function handleSave() {
-  isSaving.value = true
   errorMessage.value = ''
   successMessage.value = ''
+
+  if (!title.value.trim()) {
+    errorMessage.value = 'Please enter a quiz title'
+    return
+  }
+
+  if (questions.value.length === 0) {
+    errorMessage.value = 'Please add at least one question'
+    return
+  }
+
+  for (let i = 0; i < questions.value.length; i++) {
+    const q = questions.value[i]
+    if (!q.question.trim()) {
+      errorMessage.value = `Question ${i + 1} cannot be empty`
+      return
+    }
+    if (q.type === 'multiple-choice') {
+      const filled = q.options.filter(o => o.trim())
+      if (filled.length < 2) {
+        errorMessage.value = `Question ${i + 1} must have at least 2 answer choices`
+        return
+      }
+    }
+    if (!q.correctAnswer) {
+      errorMessage.value = `Please select a correct answer for question ${i + 1}`
+      return
+    }
+  }
+
+  isSaving.value = true
   const quizPayload = {
     title: title.value,
-    questions: questions.value.filter(q => q.question.trim()).map(q => ({
+    questions: questions.value.map(q => ({
       questionText: q.question,
       type: q.type === 'multiple-choice'
         ? 'MULTIPLE_CHOICE'


### PR DESCRIPTION
## Summary
- enforce required field checks when saving flashcards
- validate note title and content
- validate quiz details, question text, choices, and answers

## Testing
- `npm run lint` *(fails: run-s not found)*
- `npm run type-check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671b3297248322af482580368ac48a