### PR TITLE
Fix auth view tests

### DIFF
--- a/src/views/authentication_view/LoginView.vue
+++ b/src/views/authentication_view/LoginView.vue
@@ -100,7 +100,12 @@
                   </svg>
                 </div>
                 <div class="ml-3">
-                  <p class="text-sm text-red-700">{{ loginError }}</p>
+                  <p
+                    class="text-sm text-red-700"
+                    data-testid="login-error-message"
+                  >
+                    {{ loginError }}
+                  </p>
                 </div>
               </div>
             </div>
@@ -152,7 +157,11 @@
                     placeholder="Enter your username"
                   />
                 </div>
-                <p v-if="errors.username" class="mt-2 text-sm text-red-600">
+                <p
+                  v-if="errors.username"
+                  class="mt-2 text-sm text-red-600"
+                  data-testid="login-username-error"
+                >
                   {{ errors.username }}
                 </p>
               </div>
@@ -194,7 +203,11 @@
                     placeholder="Enter your password"
                   />
                 </div>
-                <p v-if="errors.password" class="mt-2 text-sm text-red-600">
+                <p
+                  v-if="errors.password"
+                  class="mt-2 text-sm text-red-600"
+                  data-testid="login-password-error"
+                >
                   {{ errors.password }}
                 </p>
               </div>

--- a/src/views/authentication_view/RegisterView.vue
+++ b/src/views/authentication_view/RegisterView.vue
@@ -139,7 +139,11 @@
                       placeholder="First name"
                     />
                   </div>
-                  <p v-if="errors.firstName" class="mt-2 text-sm text-red-600">
+                  <p
+                    v-if="errors.firstName"
+                    class="mt-2 text-sm text-red-600"
+                    data-testid="first-name-error"
+                  >
                     {{ errors.firstName }}
                   </p>
                 </div>
@@ -183,7 +187,11 @@
                       placeholder="Last name"
                     />
                   </div>
-                  <p v-if="errors.lastName" class="mt-2 text-sm text-red-600">
+                  <p
+                    v-if="errors.lastName"
+                    class="mt-2 text-sm text-red-600"
+                    data-testid="last-name-error"
+                  >
                     {{ errors.lastName }}
                   </p>
                 </div>
@@ -226,7 +234,13 @@
                     placeholder="Enter your email"
                   />
                 </div>
-                <p v-if="errors.email" class="mt-2 text-sm text-red-600">{{ errors.email }}</p>
+                <p
+                  v-if="errors.email"
+                  class="mt-2 text-sm text-red-600"
+                  data-testid="email-error"
+                >
+                  {{ errors.email }}
+                </p>
               </div>
 
               <!-- Username Field -->
@@ -266,7 +280,11 @@
                     placeholder="Choose a username"
                   />
                 </div>
-                <p v-if="errors.userName" class="mt-2 text-sm text-red-600">
+                <p
+                  v-if="errors.userName"
+                  class="mt-2 text-sm text-red-600"
+                  data-testid="username-error"
+                >
                   {{ errors.userName }}
                 </p>
               </div>
@@ -312,7 +330,11 @@
                       placeholder="Create password"
                     />
                   </div>
-                  <p v-if="errors.password" class="mt-2 text-sm text-red-600">
+                  <p
+                    v-if="errors.password"
+                    class="mt-2 text-sm text-red-600"
+                    data-testid="password-error"
+                  >
                     {{ errors.password }}
                   </p>
                 </div>
@@ -356,7 +378,11 @@
                       placeholder="Confirm password"
                     />
                   </div>
-                  <p v-if="errors.confirmPassword" class="mt-2 text-sm text-red-600">
+                  <p
+                    v-if="errors.confirmPassword"
+                    class="mt-2 text-sm text-red-600"
+                    data-testid="confirm-password-error"
+                  >
                     {{ errors.confirmPassword }}
                   </p>
                 </div>


### PR DESCRIPTION
## Summary
- expose element selectors for authentication error messages

## Testing
- `npx vitest run` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_687617413b548322bdbfa9bc925851da